### PR TITLE
Center and add more spacing between the sponsor logos #31

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,9 +20,9 @@
 {{ end }}
 
 {{ define "main" }}
-    <section class="container sponsor-images margin-bottom-40" id="sponsors">
+    <section class="container sponsor-images" id="sponsors">
         <div class="row">
-            <h2 class="highlight left">Sponsored by</h2>
+            <h2 class="highlight">Sponsored by</h2>
         </div>
         <ul class="list-inline text-center">
             <li>

--- a/less/styles.less
+++ b/less/styles.less
@@ -84,7 +84,7 @@ h2.highlight {
 .sponsor-images li img {
     display: inline-block;
     max-height: 77px;
-    padding-right: 15px;
+    padding-right: 25px;
     padding-bottom: 20px;
 }
 


### PR DESCRIPTION
Increased sponsor image right padding by 10px, removed bottom margin on
sponsor image section, and centered the highlighted the `Sponsored by`
heading.

Change-Id: I481fa077b9595f47b86b482906d446a840fd682e
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>