### PR TITLE
board image title text #47

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -75,7 +75,8 @@
                 <h2 class="highlight left">About OSDForum</h2>
                 <div class="inline-image hidden-xs">
                 	<img class="img img-responsive hidden-xs pull-right" src="/images/risc-v-board.jpg" alt="RISC-V dev board" />
-                    <div class="image-caption text-center">RISC-V dev board attendees will keep</div>
+                  <div class="clearfix"></div>
+                  <div class="image-caption text-center">RISC-V dev board attendees will keep</div>
                 </div>
                 <p>The Open Source Developer Forum is a workshop that brings open source SW and HW (chips, boards and systems) developers together to collaborate and learn. The OSDForum includes talks from leading industry and academic experts focused on IoT, Edge and Machine Learning development leveraging open source SW and HW building blocks. The agenda also includes a hands on bring up session using a <a href="https://open-isa.org/">RISC-V based development board</a> that attendees can keep. Made possible by the generous support of our sponsors, the OSDForum is a non-profit event with low attendee fees of $50 for industry attendees and $25 for academic attendees (includes the full day of talks, breaks, lunch and a RISC-V development board).</p>
                 <p><strong>Registration is limited, so don't delay - <a href="https://osdforum.eventbrite.com/" target="_blank">register today!</a></strong></p>
@@ -83,6 +84,7 @@
             </div>
             <div class="col-xs-24 visible-xs">
                 <img class="img img-responsive" src="/images/risc-v-board.jpg" alt="RISC-V dev board" />
+                <div class="clearfix"></div>
                 <div class="image-caption text-center">RISC-V dev board attendees will keep</div>
             </div>
         </div>


### PR DESCRIPTION
Added clearfix between image and caption text to fix chrome float issues

Change-Id: Iab4b6366c5b23a326b2bd76fcd097c1a356544e0
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>