### PR TITLE
Agenda Update #48

### DIFF
--- a/data/agenda.yml
+++ b/data/agenda.yml
@@ -18,7 +18,7 @@ items:
       start: 9:45am EDT
     - name: 'Kickstart RISC-V VM - a design environment. A pre-configured VM to enable Open Source Processor Development'
       presenter: 
-        - name: Afredo Herrera
+        - name: Alfredo Herrera
           affiliation: BTA Design Services
       start: 10:15am EDT
       handson: true
@@ -26,20 +26,20 @@ items:
       presenter: 
       start: 10:45am EDT
       affiliate: 
-    - name: 'Being Productive with Open Source Tools: Eclipse IDE and C/C++ Compiler'
-      presenter: 
-        - name: Jonah Graham
-          affiliation: Kichwa Coders
-      start: 11:15am EDT
-      handson: true
     - name: Vega board SDK, open-isa.org and RV32M1
       presenter: 
         - name: Jerry Zeng
           affiliation: NXP
+      start: 11:15am EDT
+      handson: true
+    - name: 'Being Productive with Open Source Tools: Eclipse IDE and C/C++ Compiler'
+      presenter: 
+        - name: Jonah Graham
+          affiliation: Kichwa Coders
       start: 11:45am EDT
       handson: true
-    - name: 45m Lunch
-      start: 12:30pm EDT
+    - name: 60m Lunch
+      start: 12:15pm EDT
     - name: Zephyr + IoT wireless connectivity using the Vega board
       presenter: 
         - name: Jerry Zeng

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -130,10 +130,11 @@
 		                    <td>{{ if eq .handson true }}<strong>Hands-on: </strong>{{ end }}{{ .name }}</td>
 		                    <td>
 		                      {{ if (isset $agendaItem "presenter") }}
-			                          <p>
+			                          <ul>
                                 {{ range $index, $p:=.presenter }}
-                                    {{ $p.name }} (<em>{{ $p.affiliation }}</em>){{ if ne (add $index 1) (len $agendaItem.presenter) }}, {{ end }}
-                                {{ end }}</p>
+                                    <li>{{ $p.name }} (<em>{{ $p.affiliation }}</em>)</li>
+                                {{ end }}
+                                </ul>
                               {{ end }}
 		                    </td>
 		                </tr>

--- a/less/styles.less
+++ b/less/styles.less
@@ -96,7 +96,10 @@ h2.highlight {
         margin: 15px 0 0 auto;
     }
 }
-
+#agenda ul {
+  list-style: none;
+  padding-left: 0;
+}
 .supporter-images li img {
     display: inline-block;
     max-height: 77px;


### PR DESCRIPTION
Updated agenda to fix typo, change sessions times. Updated layout to use
a list instead of paragraph to list presenters

Change-Id: Ia30977d9b0dbee104fce4d85cd9b85b791e4a98e
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>