### PR TITLE
Speaker Change #57

### DIFF
--- a/data/agenda.yml
+++ b/data/agenda.yml
@@ -28,7 +28,7 @@ items:
       affiliate: 
     - name: Vega board SDK, open-isa.org and RV32M1
       presenter: 
-        - name: Jerry Zeng
+        - name: Juan Carlos Pacheco
           affiliation: NXP
       start: 11:15am EDT
       handson: true
@@ -42,13 +42,13 @@ items:
       start: 12:15pm EDT
     - name: Zephyr + IoT wireless connectivity using the Vega board
       presenter: 
-        - name: Jerry Zeng
+        - name: Juan Carlos Pacheco
           affiliation: NXP
       start: 1:15pm EDT
       handson: true
     - name: Zephyr + MicroPython + Littlevgl on the Vega board
       presenter: 
-        - name: Jerry Zeng
+        - name: Juan Carlos Pacheco
           affiliation: NXP
       start: 2pm EDT
       handson: true


### PR DESCRIPTION
Updated NXP sessions, changing speaker from Jerry Zeng to Juan Carlos
Pacheco.

Change-Id: Ib1017c9b6ddc0c6d53b12702ecde8ffbf3ba4d32
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>