### PR TITLE
OSD Forum website needs to have the Code of Conduct added #80

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,10 @@ enableRobotsTXT = true
   hrefTargetBlank = true
   
 [[menu.main]]
+  name = "Code of Conduct"
+  url = "https://events.eclipse.org/code-of-conduct/"
+
+[[menu.main]]
   name = "Past events"
   
 [[menu.main]]


### PR DESCRIPTION
Added link to events.eclipse.org code of conduct as a main menu item.

Fixes #80

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>