### PR TITLE
fix Agenda mobile style

### DIFF
--- a/less/styles.less
+++ b/less/styles.less
@@ -185,7 +185,7 @@ h2.highlight {
 .eclipsefdn-agenda-schedule {
   @media (max-width: @screen-xs-max) {
     table {
-      font-size: 12px;
+      font-size: 14px;
     }
   }
 }

--- a/less/styles.less
+++ b/less/styles.less
@@ -104,9 +104,18 @@ h2.highlight {
   list-style: none;
   padding-left: 0;
 }
-#agenda .btn {
-  padding: 5px 25px;
-  border-radius: 5px;
+
+#agenda {
+  .btn {
+    padding: 5px 25px;
+    border-radius: 5px;
+  }
+
+  @media (max-width: @screen-xs-max) {
+    .btn {
+      padding: 5px 10px;
+    }
+  }
 }
 
 .side-by-side img {
@@ -172,6 +181,15 @@ h2.highlight {
         color: #fff;
     }
 }
+
+.eclipsefdn-agenda-schedule {
+  @media (max-width: @screen-xs-max) {
+    table {
+      font-size: 12px;
+    }
+  }
+}
+
 @media (max-width: 991px) {
   .featured-jumbotron h1 {
     font-size: 52px;


### PR DESCRIPTION
Part of https://github.com/EclipseFdn/hugo-solstice-theme/issues/188

Actually, it's not quite an issue of https://github.com/EclipseFdn/hugo-solstice-theme, it's more because of the custom style in osdforum.org

I'm thinking of transferring that issue to here

Signed-off-by: Yi Liu <yi.liu@eclipse-foundation.org>